### PR TITLE
Rework isomorphic mass assign.

### DIFF
--- a/Source/BoardGeometry.cpp
+++ b/Source/BoardGeometry.cpp
@@ -47,6 +47,9 @@ TerpstraBoardGeometry::TerpstraBoardGeometry()
 		this->rightUpwardLines.add(StraightLine({ 54, 53 }));
 
 		this->firstColumnOffsets = Array<int>({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 5 });
+		this->rowOffsets = Array<int>({-4, -3, -3, -2, -2, -1, -1, 0, 0, 2, 6});
+		this->boardXOffset = 7;
+		this->boardYOffset = -2;
 	}
 	else
 	{
@@ -77,14 +80,32 @@ TerpstraBoardGeometry::TerpstraBoardGeometry()
 		this->rightUpwardLines.add(StraightLine({ 55, 53 }));
 
 		this->firstColumnOffsets = Array<int>({ 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 4 });
+		this->rowOffsets = Array<int>({-4, -3, -3, -2, -2, -1, -1, 0, 0, 2, 5});
+		this->boardXOffset = 7;
+		this->boardYOffset = -2;
 	}
-  
+
 	maxHorizontalLineSize = 0;
 
 	for (auto line : horizontalLines)
 		if (line.size() > maxHorizontalLineSize)
 			maxHorizontalLineSize = line.size();
 
+}
+
+// Given a board number and key index, compute Cartesian coordinates for the given key,
+// the x axis is the shallow diagonal, and the y axis is the right-upward diagonal.
+// (0,0) is at the top left, so most coordinates are negative, but that's okay for our purposes.
+Point<int> TerpstraBoardGeometry::coordinatesForKey (int boardIndex, int keyIndex) const {
+	for (int lineIx = 0; lineIx < this->horizontalLines.size(); lineIx++) {
+		int rowIx = this->horizontalLines[lineIx].indexOf(keyIndex);
+		if (rowIx != -1) {
+			return (Point<int>(this->boardXOffset * boardIndex + rowIx + this->rowOffsets[lineIx], this->boardYOffset * boardIndex - lineIx));
+		}
+	}
+	// If we get here, the requested key was out of range.
+	jassert(false);
+	return Point<int>(0,0);
 }
 
 // returns the unique straight line that contains the given field

--- a/Source/BoardGeometry.h
+++ b/Source/BoardGeometry.h
@@ -51,12 +51,17 @@ public:
 
 	Array<Point<int>> getOctaveCoordinates(int boardIndex) const;
 
+	Point<int> coordinatesForKey (int boardIndex, int keyIndex) const;
+
 	// Attributes
 private:
 	StraightLineSet	horizontalLines;
 	StraightLineSet	rightUpwardLines;
-	Array<int>		firstColumnOffsets;
-	int				maxHorizontalLineSize;
+	Array<int> firstColumnOffsets;
+	Array<int> rowOffsets; // Horizonal offset of each horizontal line on the board, relative to the lower left key.
+	int boardXOffset; // Offset along shallow diagonals between analogous keys from one board to the next (typically 7)
+	int boardYOffset; // Offset along up/right diagonals between analogous keys from one board to the next (typically -2)
+	int maxHorizontalLineSize;
 };
 
 #endif  // BOARDGEOMETRY_H_INCLUDED

--- a/Source/MappingLogic.cpp
+++ b/Source/MappingLogic.cpp
@@ -61,6 +61,7 @@ juce::Colour MappingLogicBase::indexToColour(int inx) const
 
 void MappingLogicBase::indexToTerpstraKey(int inx, TerpstraKey& keyData) const
 {
+    keyData.keyType = LumatoneKeyType::noteOnNoteOff;
 	keyData.channelNumber = indexToMIDIChannel(inx);
 	keyData.noteNumber = indexToMIDINote(inx);
 

--- a/TerpstraSysEx.jucer
+++ b/TerpstraSysEx.jucer
@@ -300,7 +300,7 @@
   </MAINGROUP>
   <EXPORTFORMATS>
     <LINUX_MAKE targetFolder="Builds/Linux" smallIcon="fwSyLL" bigIcon="yjLw0u"
-                linuxExtraPkgConfig="libssh2" extraDefs="HAVE_ARPA_INET_H=1 HAVE_UNISTD_H=1 HAVE_POLL_H=1 SERVERHOST1=&quot;192.168.6.2&quot; SERVERHOST2=&quot;192.168.7.2&quot;">
+                linuxExtraPkgConfig="libssh2" extraDefs="HAVE_ARPA_INET_H=1 HAVE_UNISTD_H=1 HAVE_POLL_H=1 SERVERHOST1=&quot;192.168.6.2&quot; SERVERHOST2=&quot;192.168.7.2&quot; JUCE_MODAL_LOOPS_PERMITTED=1">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" libraryPath="/usr/X11R6/lib/" isDebug="1" optimisation="1"
                        targetName="LumatoneSetup"/>


### PR DESCRIPTION
It should always assign all keys now, and handles out-of-range values by wrapping. I was getting tired of manually editing the channels and subtracting 1 or 2 from them mod 16 in a separate program.

Another change I think should happen, but I haven't done yet, is that I *always* open the colour assignment and rotate it one notch, since the default assignment is very Lydian-focused in a way which is kind of confusing. So, a better default would just be to start the white keys a fifth/generator down from 0.