### PR TITLE
Build Lumatone Editor for Linux and macOS

### DIFF
--- a/.github/workflows/build-lte.yml
+++ b/.github/workflows/build-lte.yml
@@ -35,4 +35,32 @@ jobs:
           name: LumatoneSetup-Linux
           path: Builds/Linux/build/LumatoneSetup
 
+  build-lte-macos:
+    name: Build Lumatone Editor (macOS)
 
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install JUCE to $HOME
+        run: |
+          wget https://github.com/juce-framework/JUCE/releases/download/6.1.5/juce-6.1.5-osx.zip
+          unzip -d ~ juce-6.1.5-osx.zip
+      - name: Prepare dependencies
+        run: |
+          sudo mkdir -p /Users/soundtoys/Programming/Vito/TerpstraSysEx.2014
+          sudo cp -r Libraries /Users/soundtoys/Programming/Vito/TerpstraSysEx.2014
+      - name: Build Lumatone Editor
+        run: |
+          ~/JUCE/Projucer.app/Contents/MacOS/Projucer --resave TerpstraSysEx.jucer
+          cd Builds/MacOSX
+          xcodebuild -configuration Release
+      - name: List build directory
+        run: |
+          cd Builds/MacOSX
+          find .
+      - name: Upload Lumatone Editor
+        uses: actions/upload-artifact@v2
+        with:
+          name: LumatoneSetup-macOS
+          path: Builds/MacOSX/build/Release

--- a/.github/workflows/build-lte.yml
+++ b/.github/workflows/build-lte.yml
@@ -1,0 +1,38 @@
+name: Build Lumatone Editor
+
+on: [push, pull_request]
+
+env: {}
+
+jobs:
+  build-lte-linux:
+    name: Build Lumatone Editor (Linux)
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install JUCE to $HOME
+        run: |
+          wget https://github.com/juce-framework/JUCE/releases/download/6.1.5/juce-6.1.5-linux.zip
+          unzip -d ~ juce-6.1.5-linux.zip
+      - name: Install APT dependencies
+        run: |
+          sudo apt update
+          sudo apt install libssh2-1-dev libasound2-dev libjack-jackd2-dev ladspa-sdk libcurl4-openssl-dev  libfreetype6-dev libx11-dev libxcomposite-dev libxcursor-dev libxcursor-dev libxext-dev libxinerama-dev libxrandr-dev libxrender-dev libwebkit2gtk-4.0-dev libglu1-mesa-dev mesa-common-dev
+      - name: Build Lumatone Editor
+        run: |
+          ~/JUCE/Projucer --resave TerpstraSysEx.jucer
+          cd Builds/Linux
+          make CONFIG=Release
+      - name: List build directory
+        run: |
+          cd Builds/Linux
+          find
+      - name: Upload Lumatone Editor
+        uses: actions/upload-artifact@v2
+        with:
+          name: LumatoneSetup-Linux
+          path: Builds/Linux/build/LumatoneSetup
+
+

--- a/TerpstraSysEx.jucer
+++ b/TerpstraSysEx.jucer
@@ -303,9 +303,9 @@
                 linuxExtraPkgConfig="libssh2" extraDefs="HAVE_ARPA_INET_H=1 HAVE_UNISTD_H=1 HAVE_POLL_H=1 SERVERHOST1=&quot;192.168.6.2&quot; SERVERHOST2=&quot;192.168.7.2&quot;">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" libraryPath="/usr/X11R6/lib/" isDebug="1" optimisation="1"
-                       targetName="LumatoneSetup"/>
+                       targetName="LumatoneSetup" defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
         <CONFIGURATION name="Release" libraryPath="/usr/X11R6/lib/" isDebug="0" optimisation="2"
-                       targetName="LumatoneSetup"/>
+                       targetName="LumatoneSetup" defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_gui_extra" path="..\..\JUCE\modules"/>

--- a/TerpstraSysEx.jucer
+++ b/TerpstraSysEx.jucer
@@ -325,9 +325,11 @@
                smallIcon="fwSyLL">
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="LumatoneSetup"
-                       osxArchitecture="64BitIntel" libraryPath="../../Libraries/mac/lib"/>
+                       osxArchitecture="64BitIntel" libraryPath="../../Libraries/mac/lib"
+                       defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
         <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="LumatoneSetup"
-                       osxArchitecture="64BitIntel" libraryPath="../../Libraries/mac/lib"/>
+                       osxArchitecture="64BitIntel" libraryPath="../../Libraries/mac/lib"
+                       defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_gui_extra" path="..\..\JUCE\modules"/>


### PR DESCRIPTION
A first step towards the automation of the build process. I used Linux as a POC platform since Linux binaries are not available for download on the official Lumatone website and, therefore, provide the greatest additional benefit.

The binary (LumatoneEditor) is built for every commit and is attached to the Github action run (Example: https://github.com/Woyten/TerpstraSysEx.2014/actions/runs/1870114778). This means, Github actions need to be activated for this repo. This is just a setting.

The binary is available as long as the build log is available (usually for 90 days) s.t. this is not a definite solution.

Edit: Added automated build for macOS (without signing).