### PR TITLE
Build Lumatone Editor for Windows

### DIFF
--- a/.github/workflows/build-lte.yml
+++ b/.github/workflows/build-lte.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           name: LumatoneSetup-Linux
           path: Builds/Linux/build/LumatoneSetup
+          if-no-files-found: error
 
   build-lte-macos:
     name: Build Lumatone Editor (macOS)
@@ -64,3 +65,39 @@ jobs:
         with:
           name: LumatoneSetup-macOS
           path: Builds/MacOSX/build/Release
+          if-no-files-found: error
+
+  build-lte-windows:
+    name: Build Lumatone Editor (Windows)
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: microsoft/setup-msbuild@v1.1
+      - name: Install JUCE to C:\
+        run: |
+          Invoke-WebRequest https://github.com/juce-framework/JUCE/releases/download/6.1.5/juce-6.1.5-windows.zip -O juce-6.1.5-windows.zip
+          7z x juce-6.1.5-windows.zip -oC:\
+      - name: Build Lumatone Editor
+        run: |
+          bash -c '/c/JUCE/Projucer --resave TerpstraSysEx.jucer'
+          cd Builds/VisualStudio2019
+          msbuild LumatoneSetup.sln /p:configuration=Release
+      - name: List build directory
+        run: |
+          cd Builds/VisualStudio2019
+          Get-ChildItem -Recurse
+      - name: Upload Lumatone Editor
+        uses: actions/upload-artifact@v2
+        with:
+          name: LumatoneSetup-Windows
+          path: Builds/VisualStudio2019/x64/Release/App/LumatoneSetup.exe
+          if-no-files-found: error
+      - name: Upload dynamic libraries
+        uses: actions/upload-artifact@v2
+        with:
+          name: LumatoneSetup-Windows
+          path: Libraries/win64/bin/*.dll
+          if-no-files-found: error
+

--- a/TerpstraSysEx.jucer
+++ b/TerpstraSysEx.jucer
@@ -304,8 +304,8 @@
       <CONFIGURATIONS>
         <CONFIGURATION name="Debug" libraryPath="/usr/X11R6/lib/" isDebug="1" optimisation="1"
                        targetName="LumatoneSetup" defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
-        <CONFIGURATION name="Release" libraryPath="/usr/X11R6/lib/" isDebug="0" optimisation="2"
-                       targetName="LumatoneSetup" defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
+        <CONFIGURATION name="Release" libraryPath="/usr/X11R6/lib/" isDebug="0" targetName="LumatoneSetup"
+                       defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_gui_extra" path="..\..\JUCE\modules"/>
@@ -327,9 +327,8 @@
         <CONFIGURATION name="Debug" isDebug="1" optimisation="1" targetName="LumatoneSetup"
                        osxArchitecture="64BitIntel" libraryPath="../../Libraries/mac/lib"
                        defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
-        <CONFIGURATION name="Release" isDebug="0" optimisation="3" targetName="LumatoneSetup"
-                       osxArchitecture="64BitIntel" libraryPath="../../Libraries/mac/lib"
-                       defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
+        <CONFIGURATION name="Release" isDebug="0" targetName="LumatoneSetup" osxArchitecture="64BitIntel"
+                       libraryPath="../../Libraries/mac/lib" defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_gui_extra" path="..\..\JUCE\modules"/>

--- a/TerpstraSysEx.jucer
+++ b/TerpstraSysEx.jucer
@@ -366,7 +366,7 @@
         <CONFIGURATION isDebug="1" name="Debug" headerPath="$(ProjectDir)..\..\Libraries\win64\include"
                        libraryPath="$(ProjectDir)..\..\Libraries\win64\lib"/>
         <CONFIGURATION isDebug="0" name="Release" libraryPath="$(ProjectDir)..\..\Libraries\win64\lib"
-                       headerPath="$(ProjectDir)..\..\Libraries\win64\include"/>
+                       headerPath="$(ProjectDir)..\..\Libraries\win64\include" defines="JUCE_MODAL_LOOPS_PERMITTED=1"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_gui_extra"/>


### PR DESCRIPTION
This PR adds automated builds for Windows. The Windows executable worked out-of-the box on my Windows machine after I added the DLLs from the repo to the zip file.

The PR also changes Linux to use `-O3` instead of `-O2` optimization (see comments in the code).